### PR TITLE
some slight re-arranging of the mod file

### DIFF
--- a/src/main/java/com/minecraft_vr/VRBase.java
+++ b/src/main/java/com/minecraft_vr/VRBase.java
@@ -8,9 +8,17 @@ import com.minecraft_vr.render.FrameBufferShim;
 import com.minecraft_vr.render.VRRenderer;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.shader.Framebuffer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLModDisabledEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.ReflectionHelper;
 
 @Mod(modid = VRBase.MODID, version = VRBase.VERSION, name = VRBase.NAME, canBeDeactivated = true, useMetadata = false )
 public class VRBase
@@ -19,27 +27,68 @@ public class VRBase
     public static final String VERSION = "1.0";
     public static final String NAME = "VR Base";
     
+    EntityRenderer oldRenderer;
+    EntityRenderer newRenderer;
+    Framebuffer oldBuffer;
+    Framebuffer newBuffer;
+    
     public static VRBase GetInstance()
     {
     	return inst;
-    	
     }
+    
+    @Instance(MODID)
     private static VRBase inst;
     
     @EventHandler
     public void init(FMLInitializationEvent event)
     {
-    	inst = this;
-
     	//Swap out renderer
+    	swap();
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @EventHandler
+    public void modDisableEvent(FMLModDisabledEvent evt)
+    {
+    	System.out.println("Disabling VR mode");
+    	if(Minecraft.getMinecraft().entityRenderer==newRenderer)
+    		swap();
+    }
+    
+    private void swap()
+    {
         Minecraft mc = Minecraft.getMinecraft();
-        mc.entityRenderer = new VRRenderer(mc.entityRenderer);
-        mc.framebufferMc = new FrameBufferShim( mc.framebufferMc );
+        
+        if(oldBuffer == null)
+        {
+        	oldRenderer = mc.entityRenderer;
+        	oldBuffer = mc.framebufferMc;
+        	newBuffer = new FrameBufferShim(mc.framebufferMc);
+        	newRenderer = new VRRenderer(mc.entityRenderer);
+        }
+        if(mc.entityRenderer == oldRenderer)
+        {
+        	mc.entityRenderer = newRenderer;
+        	mc.framebufferMc = newBuffer;
+        }
+        else
+        {
+        	mc.entityRenderer = oldRenderer;
+        	mc.framebufferMc = oldBuffer;
+        }
+        
     }
     
     public void RegisterPlugin( IBodyOrientation bodyOrient )
     {
     	
+    }	   
+    
+    @SubscribeEvent
+    public void EntityJoinWorld(EntityJoinWorldEvent evt)
+    {
+    	evt.entity.ignoreFrustumCheck = true;
     }
     
     public static IBodyOrientation bodyOrientation;


### PR DESCRIPTION
made it use the built in instance setting method that forge has.  also
made it set the ignoreFrustumCheck to true for all entities, this fixes
the bug where they are only visible on the left view

the swap() method was an attempt to allow this mod to be turned on and off using the disable event, it doesn't seem to function properly.  the main reason for this pull request is for the EntityJoinWorldEvent handler, which fixes a bug where small entities don't render on both views.
